### PR TITLE
Improve rvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ wsl
 cache/
 **/*.zwc
 .vscode/
+CLAUDE.md

--- a/antidote_plugins_darwin.txt
+++ b/antidote_plugins_darwin.txt
@@ -24,4 +24,4 @@ romkatv/powerlevel10k                                     # Fast, feature-rich Z
 
 junegunn/fzf           path:shell/key-bindings.zsh        # fzf keybindings (Ctrl-R, etc)
 junegunn/fzf           path:shell/completion.zsh          # fzf-enhanced completions
-ohmyzsh/ohmyzsh        path:plugins/fzf                   # fzf env setup and integration
+# ohmyzsh/ohmyzsh        path:plugins/fzf                 # fzf env setup (disabled: runs fzf --version, FZF_DEFAULT_COMMAND now set in early_20_environment.zsh)

--- a/includes/early_07_colors.zsh
+++ b/includes/early_07_colors.zsh
@@ -2,7 +2,12 @@
 case $OSTYPE in
   darwin*)
     if [[ -f /opt/homebrew/bin/gdircolors && -f ${ZSH}/dircolors ]]  ; then
-      eval $(/opt/homebrew/bin/gdircolors -b ${ZSH}/dircolors)
+      # Cache dircolors output for performance (~10ms saved)
+      local dircolors_cache="${ZSH_CACHE_DIR}/dircolors_cache.zsh"
+      if [[ ! -f "$dircolors_cache" || "${ZSH}/dircolors" -nt "$dircolors_cache" ]]; then
+        /opt/homebrew/bin/gdircolors -b ${ZSH}/dircolors > "$dircolors_cache"
+      fi
+      source_compiled "$dircolors_cache"
     else
       export CLICOLOR=1
       export LSCOLORS=gxfxbEaEBxxEhEhBaDaCaD
@@ -11,7 +16,12 @@ case $OSTYPE in
   ;;
   linux*)
     if [[ -f ${ZSH}/dircolors ]]; then
-      eval `dircolors ${ZSH}/dircolors`
+      # Cache dircolors output for performance
+      local dircolors_cache="${ZSH_CACHE_DIR}/dircolors_cache.zsh"
+      if [[ ! -f "$dircolors_cache" || "${ZSH}/dircolors" -nt "$dircolors_cache" ]]; then
+        dircolors ${ZSH}/dircolors > "$dircolors_cache"
+      fi
+      source_compiled "$dircolors_cache"
     fi
   ;;
 esac

--- a/includes/early_20_environment.zsh
+++ b/includes/early_20_environment.zsh
@@ -68,3 +68,14 @@ export FZF_DEFAULT_OPTS='
   --color info:141,prompt:84,spinner:212,pointer:212,marker:212
   --height 100%
 '
+
+# FZF default command setup (replaces ohmyzsh/ohmyzsh fzf plugin to save ~9ms)
+if [[ -z "$FZF_DEFAULT_COMMAND" ]]; then
+  if (( $+commands[fd] )); then
+    export FZF_DEFAULT_COMMAND='fd --type f --hidden --exclude .git'
+  elif (( $+commands[rg] )); then
+    export FZF_DEFAULT_COMMAND='rg --files --hidden --glob "!.git/*"'
+  elif (( $+commands[ag] )); then
+    export FZF_DEFAULT_COMMAND='ag -l --hidden -g "" --ignore .git'
+  fi
+fi

--- a/includes/early_50_powerlevel10k.zsh
+++ b/includes/early_50_powerlevel10k.zsh
@@ -60,7 +60,7 @@ function prompt_goenv_version() {
 # powerlevel 10 custom kube_context segment
 prompt_kube_context() {
   # powerlevel10 has a builtin context, but want some extra features
-  CLUSTER_FILE=${ZSH_CACHE_DIR}/k8s-clusters
+  CLUSTER_FILE=${ZSH_DIR}/k8s-clusters
   local context=`test -f ~/.kube/config && grep current-context ~/.kube/config | cut -d\  -f2`
   if [[ -z $context ]]; then
     context='unknown'
@@ -104,6 +104,7 @@ if [ -z "${SSH_CLIENT}" ]; then
     aws
     goenv_version
     pyenv_version
+    kube_context
     vcs
     newline
     dir_writable

--- a/includes/init.zsh
+++ b/includes/init.zsh
@@ -9,11 +9,18 @@ is_stale_file() {
     return 0  # Treat missing files as stale
   fi
 
-  local now epoch
-  now=$(date +%s)
-  epoch=$(stat -f %m "$file" 2>/dev/null)
+  # Cache the current time to avoid repeated calls
+  # Use zsh's builtin EPOCHSECONDS instead of external date command (~10ms faster)
+  if [[ -z "$_STALE_CHECK_NOW" ]]; then
+    _STALE_CHECK_NOW=$EPOCHSECONDS
+  fi
 
-  (( (now - epoch) > max_age_seconds ))
+  # Use zsh's builtin zstat module for fast file stat (much faster than external stat command)
+  zmodload -F zsh/stat b:zstat 2>/dev/null
+  local epoch
+  epoch=$(zstat +mtime "$file" 2>/dev/null)
+
+  (( (_STALE_CHECK_NOW - epoch) > max_age_seconds ))
 }
 
 prepend_path() {

--- a/includes/late_10_functions.zsh
+++ b/includes/late_10_functions.zsh
@@ -197,3 +197,17 @@ resrc() {
   fi
   exec zsh
 }
+
+# Custom tmux attach or new session function
+t() {
+    if tmux has-session -t default 2>/dev/null; then
+        tmux attach-session -t default
+    else
+        tmux new-session -d -s default -n TerraformDeploy
+        tmux new-window -t default -n LegacyDeploy
+        tmux new-window -t default -n TFModules
+        tmux new-window -t default -n General
+        tmux select-window -t default:0
+        tmux attach-session -t default
+    fi
+}

--- a/includes/late_50_tools.zsh
+++ b/includes/late_50_tools.zsh
@@ -138,7 +138,8 @@ if which zoxide >/dev/null 2>&1; then
   export _ZO_FZF_OPTS=${FZF_DEFAULT_OPTS}
   zoxide_init_cache="${ZSH_CACHE_DIR}/zoxide_init.zsh"
   is_stale_file "${zoxide_init_cache}" && zoxide init zsh > "${zoxide_init_cache}"
-  eval "$(cat "${zoxide_init_cache}")"
+  # Use source_compiled instead of eval with cat for better performance (~10ms saved)
+  source_compiled "${zoxide_init_cache}"
 else
   echo "zoxide not found, consider installing it!"
 fi

--- a/includes/late_50_tools.zsh
+++ b/includes/late_50_tools.zsh
@@ -56,9 +56,10 @@ if [ -d "${HOME}/.pyenv" ]; then
 fi
 
 # setup for nvm
-export NVM_DIR="$HOME/.config/nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && source  "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && source_compiled "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+# @TODO: Optimize
+# export NVM_DIR="$HOME/.config/nvm"
+# [ -s "$NVM_DIR/nvm.sh" ] && source  "$NVM_DIR/nvm.sh"  # This loads nvm
+# [ -s "$NVM_DIR/bash_completion" ] && source_compiled "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
 # setup for goenv (requires goenv 2+)
 if [ -d "${HOME}/.goenv" ]; then
@@ -83,29 +84,31 @@ if [ -d "${HOME}/.goenv" ]; then
   }
 fi
 
+# @TODO: Optimize
 # setup for rbenv
-if [ -d "${HOME}/.rbenv" ]; then
-  export PATH="${HOME}/.rbenv/bin:${PATH}"
-  rbenv_init_cache="${ZSH_CACHE_DIR}/rbenv_init.zsh"
-  if [[ ! -f "${rbenv_init_cache}" ]]; then
-    $(rbenv init - zsh > ${rbenv_init_cache})
-  fi
-  for f in ${rbenv_init_cache}(N.mh+24); do
-    $(rbenv init - zsh > ${rbenv_init_cache})
-  done
-  source_compiled ${rbenv_init_cache}
-fi
+# if [ -d "${HOME}/.rbenv" ]; then
+#   export PATH="${HOME}/.rbenv/bin:${PATH}"
+#   rbenv_init_cache="${ZSH_CACHE_DIR}/rbenv_init.zsh"
+#   if [[ ! -f "${rbenv_init_cache}" ]]; then
+#     $(rbenv init - zsh > ${rbenv_init_cache})
+#   fi
+#   for f in ${rbenv_init_cache}(N.mh+24); do
+#     $(rbenv init - zsh > ${rbenv_init_cache})
+#   done
+#   source_compiled ${rbenv_init_cache}
+# fi
 
+# @TODO: Optimize
 # Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
-if [ -f "$HOME/.rvm/scripts/rvm" ]; then
-  source_compiled "$HOME/.rvm/scripts/rvm"
-  export PATH="$PATH:$HOME/.rvm/bin"
-fi
+# if [ -f "$HOME/.rvm/scripts/rvm" ]; then
+#   source_compiled "$HOME/.rvm/scripts/rvm"
+#   export PATH="$PATH:$HOME/.rvm/bin"
+# fi
 
 # KREW (kubectl plugin manager)
-if which kubectl-krew >/dev/null 2>&1; then
-  export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-fi
+# if which kubectl-krew >/dev/null 2>&1; then
+#   export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+# fi
 
 # CircleCI CLI tool
 if which circleci > /dev/null 2>&1; then

--- a/includes/late_75_aliases.zsh
+++ b/includes/late_75_aliases.zsh
@@ -33,13 +33,13 @@ alias libpath='echo -e ${LD_LIBRARY_PATH//:/\\n}'
 # tmux alias
 if command -v tmux &>/dev/null && [[ -z ${TMUX} ]]; then
   alias tmux='tmux -2'
-  alias t='tmux attach-session -t default || tmux new-session -s default'
+  # alias t='tmux attach-session -t default || tmux new-session -s default'
+  # Note: function t() is defined in late_10_functions.zsh, don't create alias here
   alias tnew='tmux new-session -s default'
   alias tlist='tmux list-sessions'
   alias tk='tmux kill-session -t default'
-else
-  alias t='echo "tmux not found or already in a session"'
 fi
+# Note: removed 'else' clause that defined alias t, as it conflicts with function t()
 
 # Package management aliases
 if command -v dnf &>/dev/null; then

--- a/tools/zsh_profile.py
+++ b/tools/zsh_profile.py
@@ -73,13 +73,13 @@ unsetopt xtrace prompt_subst
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python script.py <log_file_path>")
+        print("Usage: python script.py <log_file_path> [threshold_ms]")
         sys.exit(1)
 
     log_file_path = sys.argv[1]
-    threshold_ms = 7  # Update with your desired threshold in milliseconds
+    threshold_ms = float(sys.argv[2]) if len(sys.argv) > 2 else 5  # Default to 5ms for aggressive optimization
     log_entries = parse_log_file(log_file_path)
 
     for entry in log_entries.entries:
         if entry.elapsed_time > threshold_ms:
-            print(f"{entry.elapsed_time} {entry.source}:{entry.line_number} {entry.command}")
+            print(f"{entry.elapsed_time:.1f}ms {entry.source}:{entry.line_number} {entry.command}")

--- a/zshrc
+++ b/zshrc
@@ -39,6 +39,9 @@ source_compiled "$ALL_COMBINED"
 [[ -f "${ZSH}/secrets.zsh" ]] && source_compiled "${ZSH}/secrets.zsh"
 [[ -f "${ZSH}/work.zsh" ]] && source_compiled "${ZSH}/work.zsh"
 
+# Clear stale file check cache (used during startup to avoid repeated date calls)
+unset _STALE_CHECK_NOW
+
 # End tracing if enabled
 if [[ "$PROFILE_STARTUP" == true || "$PROFILE_ALL" == true ]]; then
   unsetopt xtrace


### PR DESCRIPTION
Shell loads were getting slow (over 350ms....) 

Disable RVM (not regularly used, slow no matter what)
Optimize a few other calls, and move FZF plugin logic locally to avoid expensive and slow calls. 

This is now back to the 100ms target:
```
for i in {1..10}; do time zsh -i --login -c echo; done 2>&1 | grep total | awk '{total=$(NF-1); sum+=total; print total"s"} END {printf "Average: %.3fs\n", sum/NR}'

0.115s
0.096s
0.102s
0.091s
0.095s
0.098s
0.109s
0.093s
0.097s
0.108s
Average: 0.100s
``` 
however, profilng shows no single calls over 2ms except for absolute essentials, there is going to be very limited opportunities for further speed increases with the current functionality/tooling.