### PR TITLE
The zwc files were not always in the cache dir; fix that

### DIFF
--- a/includes/init.zsh
+++ b/includes/init.zsh
@@ -47,7 +47,25 @@ clean_path() {
 source_compiled() {
   local file="$1"
   [[ -f "$file" ]] || return 1
-  [[ ! -f "${file}.zwc" || "$file" -nt "${file}.zwc" ]] && zcompile "$file"
+
+  local zwc_file
+  # If file is in cache directory, compile alongside it
+  # Otherwise, compile to cache/compiled/ directory
+  if [[ "$file" == ${ZSH_CACHE_DIR}/* ]]; then
+    zwc_file="${file}.zwc"
+  else
+    # Create compiled subdirectory in cache
+    local compiled_dir="${ZSH_CACHE_DIR}/compiled"
+    [[ -d "$compiled_dir" ]] || mkdir -p "$compiled_dir"
+
+    # Generate cache filename from source path (replace / with _)
+    local rel_path="${file#${ZSH}/}"
+    local cache_name="${rel_path//\//_}"
+    zwc_file="${compiled_dir}/${cache_name}.zwc"
+  fi
+
+  # Compile if missing or stale
+  [[ ! -f "$zwc_file" || "$file" -nt "$zwc_file" ]] && zcompile "$zwc_file" "$file"
   source "$file"
 }
 

--- a/tools/test_config.zsh
+++ b/tools/test_config.zsh
@@ -196,8 +196,11 @@ if [[ $COMPILE_ERRORS -eq 0 ]]; then
   echo "${GREEN}✓${NC} All files compile to .zwc"
 
   if [[ "$FIX_MODE" == false ]]; then
-    # Clean up test compilation artifacts
-    find . -name "*.zwc" -newer zshrc -delete 2>/dev/null
+    # Clean up test compilation artifacts (they belong in cache/, not source dirs)
+    # Use (N) glob qualifier to make pattern null if no matches (zsh-specific)
+    local -a cleanup_files
+    cleanup_files=(zshrc.zwc includes/*.zwc(N) .antidote/*.zwc(N))
+    [[ ${#cleanup_files[@]} -gt 0 ]] && rm -f "${cleanup_files[@]}"
   fi
 else
   ERRORS=$((ERRORS + COMPILE_ERRORS))

--- a/zshrc
+++ b/zshrc
@@ -21,7 +21,9 @@ fi
 
 # Load core functions
 ZSH_INIT_FILE="${ZSH_INCLUDES}/init.zsh"
-[[ ! -f "${ZSH_INIT_FILE}.zwc" || "${ZSH_INIT_FILE}" -nt "${ZSH_INIT_FILE}.zwc" ]] && zcompile "${ZSH_INIT_FILE}"
+ZSH_INIT_COMPILED="${ZSH_CACHE_DIR}/compiled/includes_init.zsh.zwc"
+[[ -d "${ZSH_CACHE_DIR}/compiled" ]] || mkdir -p "${ZSH_CACHE_DIR}/compiled"
+[[ ! -f "${ZSH_INIT_COMPILED}" || "${ZSH_INIT_FILE}" -nt "${ZSH_INIT_COMPILED}" ]] && zcompile "${ZSH_INIT_COMPILED}" "${ZSH_INIT_FILE}"
 source "${ZSH_INIT_FILE}"
 
 # Combine, and compile all includes


### PR DESCRIPTION
The compiled bytecode was being stored with the source files instead of in the zsh dirs cache, fix this error.